### PR TITLE
Tutorial Use the glfw library provided by the project

### DIFF
--- a/Libraries/GLFW/Linux/libglfw.so.3
+++ b/Libraries/GLFW/Linux/libglfw.so.3
@@ -1,0 +1,1 @@
+libglfw.so.3.3

--- a/Tutorials/01 - GLFW window/run_linux.sh
+++ b/Tutorials/01 - GLFW window/run_linux.sh
@@ -18,5 +18,4 @@ fi
 # If it doesn't work for you, try adding any of the libraries below.
 #gcc $1 -lGL -lm -lX11 -lpthread -lXrandr -lXi -ldl -lglfw
 gcc $1 -lGL -lm -ldl ../../Libraries/glad/glad.c ../../Libraries/GLFW/Linux/libglfw.so.3.3 
-./a.out
-
+LD_LIBRARY_PATH="$(pwd)/../../Libraries/GLFW/Linux:${LD_LIBRARY_PATH}" ./a.out

--- a/Tutorials/02 - Quad/run_linux.sh
+++ b/Tutorials/02 - Quad/run_linux.sh
@@ -18,5 +18,4 @@ fi
 # If it doesn't work for you, try adding any of the libraries below.
 #gcc $1 -lGL -lm -lX11 -lpthread -lXrandr -lXi -ldl -lglfw
 gcc $1 -lGL -lm -ldl ../../Libraries/glad/glad.c ../../Libraries/GLFW/Linux/libglfw.so.3.3 
-./a.out
-
+LD_LIBRARY_PATH="$(pwd)/../../Libraries/GLFW/Linux:${LD_LIBRARY_PATH}" ./a.out

--- a/Tutorials/03 - Separate shader files/run_linux.sh
+++ b/Tutorials/03 - Separate shader files/run_linux.sh
@@ -18,5 +18,4 @@ fi
 # If it doesn't work for you, try adding any of the libraries below.
 #gcc $1 -lGL -lm -lX11 -lpthread -lXrandr -lXi -ldl -lglfw
 gcc $1 -lGL -lm -ldl ../../Libraries/glad/glad.c ../../Libraries/GLFW/Linux/libglfw.so.3.3 
-./a.out
-
+LD_LIBRARY_PATH="$(pwd)/../../Libraries/GLFW/Linux:${LD_LIBRARY_PATH}" ./a.out

--- a/Tutorials/04 - Getting window width and height and using them/run_linux.sh
+++ b/Tutorials/04 - Getting window width and height and using them/run_linux.sh
@@ -18,5 +18,4 @@ fi
 # If it doesn't work for you, try adding any of the libraries below.
 #gcc $1 -lGL -lm -lX11 -lpthread -lXrandr -lXi -ldl -lglfw
 gcc $1 -lGL -lm -ldl ../../Libraries/glad/glad.c ../../Libraries/GLFW/Linux/libglfw.so.3.3 
-./a.out
-
+LD_LIBRARY_PATH="$(pwd)/../../Libraries/GLFW/Linux:${LD_LIBRARY_PATH}" ./a.out

--- a/Tutorials/05 - Textures/run_linux.sh
+++ b/Tutorials/05 - Textures/run_linux.sh
@@ -18,5 +18,4 @@ fi
 # If it doesn't work for you, try adding any of the libraries below.
 #gcc $1 -lGL -lm -lX11 -lpthread -lXrandr -lXi -ldl -lglfw
 gcc $1 -lGL -lm -ldl ../../Libraries/glad/glad.c ../../Libraries/GLFW/Linux/libglfw.so.3.3 
-./a.out
-
+LD_LIBRARY_PATH="$(pwd)/../../Libraries/GLFW/Linux:${LD_LIBRARY_PATH}" ./a.out

--- a/Tutorials/06 - Uniforms/run_linux.sh
+++ b/Tutorials/06 - Uniforms/run_linux.sh
@@ -18,5 +18,4 @@ fi
 # If it doesn't work for you, try adding any of the libraries below.
 #gcc $1 -lGL -lm -lX11 -lpthread -lXrandr -lXi -ldl -lglfw
 gcc $1 -lGL -lm -ldl ../../Libraries/glad/glad.c ../../Libraries/GLFW/Linux/libglfw.so.3.3 
-./a.out
-
+LD_LIBRARY_PATH="$(pwd)/../../Libraries/GLFW/Linux:${LD_LIBRARY_PATH}" ./a.out


### PR DESCRIPTION
Use LD_LIBRARY_PATH to use the glfw library provided by the project in the run scripts under linux. Also sets the symbolic link to the library version so that the library can be properly loaded by the runtime linker.